### PR TITLE
ARXIVNG-2774: deploy submission-preview to cluster

### DIFF
--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -1,0 +1,24 @@
+# Deployment Instructions for submission-preview
+
+To install submission-preview to the development namespace in the kubernetes cluster:
+
+```
+helm install ./ --name=submission-preview \
+  --set=image.tag=0.1rc1 --tiller-namespace=development \
+  --namespace=development --set=vault.enabled=1 \
+  --set=vault.host=<VAULT_HOST_IP> --set=vault.port=8200
+```
+
+This assumes that the requisite Vault roles and policies have already been installed.
+
+To delete the pod, run:
+```
+helm del --purge submission-preview --tiller-namespace=development
+```
+
+Notes:
+- `image.tag`: this refers to the tag in [dockerhub](https://hub.docker.com/repository/docker/arxiv/submission-preview)
+- `vault.host`: the actual IP of the Vault host can be retrieved from most of the other pods, for example by running the following command on one of the existing pods, e.g.:
+```
+$ kubectl describe pod submission-ui-8447fff4b7-cbqc2 | grep VAULT_HOST
+```

--- a/deploy/preview/templates/10-deployment.yaml
+++ b/deploy/preview/templates/10-deployment.yaml
@@ -50,6 +50,8 @@ spec:
         env:
         - name: LOGLEVEL
           value: "{{ .Values.loglevel }}"
+        - name: S3_BUCKET
+          value: "{{ .Values.s3.bucket }}-{{ .Values.namespace }}"
         - name: VAULT_ENABLED
           value: "{{ .Values.vault.enabled  }}"
         - name: VAULT_HOST

--- a/deploy/preview/values.yaml
+++ b/deploy/preview/values.yaml
@@ -14,6 +14,10 @@ image:
   name: arxiv/submission-preview
   tag: changeme
 
+s3:
+  bucket: preview-submission
+  region: us-east-1
+
 vault:
   enabled: 0
   host: changeme

--- a/preview/config.py
+++ b/preview/config.py
@@ -19,7 +19,7 @@ JWT_SECRET = environ.get('JWT_SECRET', 'foosecret')
 
 NS_AFFIX = '' if NAMESPACE == 'production' else f'-{NAMESPACE}'
 
-S3_BUCKET = environ.get('S3_BUCKET', f'preview{NS_AFFIX}')
+S3_BUCKET = environ.get('S3_BUCKET', f'preview-submission{NS_AFFIX}')
 S3_VERIFY = bool(int(environ.get('S3_VERIFY', '1')))
 S3_ENDPOINT = environ.get('S3_ENDPOINT', None)
 AWS_REGION = environ.get('AWS_REGION', 'us-east-1')


### PR DESCRIPTION
Most of the effort in getting submission-preview to deploy successfully was in ensuring the Vault credentials, roles and policies were configured correctly, [per the examples in the arxiv-k8s Vault README](https://github.com/arXiv/arxiv-k8s/blob/master/vault/README.md#example-logstash-access-to-s3). Specifically, I had missed the step of creating the new role via the Kubernetes auth API to bind the k8s ServiceAccounts to the new policy.

The changes here are fairly minor fixes to configuration that initially prevented the deployment from working correctly.